### PR TITLE
Fixes the sorting and display of tasks in the task table.  Also simplifies some of the code in dropdown, dropdownEnter, dropdownFilter, and dropdownFilter functions.  

### DIFF
--- a/Client/src/Components/CreateTask/CreateTask.jsx
+++ b/Client/src/Components/CreateTask/CreateTask.jsx
@@ -6,32 +6,31 @@ import './CreateTask.css'
 
 export default function CreateTask(props){
 
-  const {groupData, input, handleInputChange, addTask, btnRef/*, 
-    dropdown*/, dropdownActive, dropdownEnter, dropdownFilter, dropdownSearch/*, dropdownSelected*/} = props;
+  const {groupData, input, handleInputChange, addTask, btnRef, 
+    dropdown, dropdownActive, dropdownEnter, dropdownFilter, dropdownSearch, dropdownSelected, selected} = props;
 
-  const [selected, setSelected] = useState('');
-  const [active, setActive] = useState(false)
-  function dropdownSelected(event) {
-    setSelected(event.target.id)
-    setActive(false)
-  }
+  // const [selected, setSelected] = useState('');
+  // const [active, setActive] = useState(false)
 
-  function dropdown() {
-    setActive(prevActive => !prevActive)
-  }
+  // function dropdownSelected(event) {
+  //   setSelected(event.target.id)
+  //   setActive(false)
+  // }
 
-  const classList = active ? "dropdown-content show" : "dropdown-content";
+  // function dropdown() {
+  //   setActive(prevActive => !prevActive)
+  // }
+
+  const classList = dropdownActive ? "dropdown-content show" : "dropdown-content";
   
   // displays elements in dropdown
   const groupListElements = groupData.map(group => {
-    if(group.group_id != 0 && group.group_id != 1) {
       if(dropdownSearch == "") {
-        return <p key = {group.group_id} id = {group.group_id} className = "create-dropdown-group" onClick={(event) => dropdownSelected(event)}>{group.title}</p>
+        return <p key = {group.group_id} id = {group.group_id} className = "create-dropdown-group" onClick={(event) => dropdownSelected(event, true)}>{group.title}</p>
       } 
       else if (group.title.toUpperCase().indexOf(dropdownSearch.toUpperCase()) === 0 && group.title != "Group") {
-        return <p key = {group.group_id} id = {group.group_id} className = "create-task-dropdown-group" onClick={(event) => dropdownSelected(event)}>{group.title}</p>
+        return <p key = {group.group_id} id = {group.group_id} className = "create-task-dropdown-group" onClick={(event) => dropdownSelected(event, true)}>{group.title}</p>
       }
-    }
   })
 
   // switches group name to name of current group selected
@@ -47,11 +46,8 @@ export default function CreateTask(props){
 
   return(
     <div className="create-task-container">
-
       <div className = "create-task">
-
         <div className="left-box">
-          
           <div className = "create-task-input-container">
             <input 
               className="input create-task-input" 
@@ -60,12 +56,12 @@ export default function CreateTask(props){
               type="text"
               name="title"
               value={input.title}
-              onChange={() => handleInputChange(event)} 
+              onChange={() => handleInputChange(event, true)} 
             />
           </div>
 
           <div className = "dropdown create-task-dropdown-container" >
-            <div className = "group dropbtn create-task-dropdown" onClick = {() => dropdown(event)}>
+            <div className = "group dropbtn create-task-dropdown" id = 'create-task-dropdown' onClick = {() => dropdown(event, true)}>
               <img className = "create-task-dropdown" src = "https://app.clockify.me/assets/ui-icons/plus-blue-req.svg" alt = "" />
               {selected == '' ? 'Group' : groupElement}
             </div>
@@ -77,8 +73,8 @@ export default function CreateTask(props){
                 placeholder = "Search/Create..." 
                 id = "create-dropdown-input"
                 name = "group" 
-                onChange = {() => dropdownFilter(event)} 
-                onKeyDown = {() => dropdownEnter(event)}
+                onChange = {() => dropdownFilter(event, true)} 
+                onKeyDown = {() => dropdownEnter(event, true)}
               />
               {groupListElements}
             </div>
@@ -95,7 +91,7 @@ export default function CreateTask(props){
               type = "time" 
               name = "startTime"
               value = {input.startTime}
-              onChange = {() => handleInputChange(event)}
+              onChange = {() => handleInputChange(event, true)}
             />
             <div className = "time-divider">-</div>
             <input 
@@ -103,7 +99,7 @@ export default function CreateTask(props){
               type = "time"
               name = "endTime"
               value = {input.endTime}
-              onChange = {() => handleInputChange(event)} 
+              onChange = {() => handleInputChange(event, true)} 
             />
           </div>
 
@@ -115,7 +111,7 @@ export default function CreateTask(props){
               type = "date" 
               name = "date"
               value = {input.date}
-              onChange = {() => handleInputChange(event)} 
+              onChange = {() => handleInputChange(event, true)} 
             />
           </div>
 

--- a/Client/src/Components/GroupedTask/GroupedTask.jsx
+++ b/Client/src/Components/GroupedTask/GroupedTask.jsx
@@ -78,6 +78,7 @@ export default function GroupedTask(props){
 //     else {return groupData[indexOfGroupSelection].taskIds.indexOf(task.id) >= 0}
 //  })
 
+
   const filteredTasks = taskData.filter(task => {
     if(groupSelection === 'default'){
       return true
@@ -98,20 +99,18 @@ export default function GroupedTask(props){
     }
     else {return new Date(a.date) - new Date(b.date)};
   });
-  // console.log('sortedTasks', sortedTasks)
 
   //Create an array of dates for which displayed tasks are assigned (if any).
   const dateList = sortedTasks.filter((task, index) => {
-    if (index > 0 && task.date) {return(task.date != sortedTasks[index - 1].date)}
+    if (index == 0 && task.date) {return true}
+    else if (task.date) {return(task.date != sortedTasks[index - 1].date)}
     else {return false}
   })
   .map(task => task.date)
-  // console.log('dateList', dateList);
 
   //Create an array of task element arrays with one array of tasks for each date in dateList and one additional array for unscheduled tasks.
   const taskElementArrays = dateList.map((date, index) => [])
   taskElementArrays.push([])
-  // console.log(taskElementArrays);
 
   function TaskComponent (task) {
     return(
@@ -133,11 +132,11 @@ export default function GroupedTask(props){
   }
 
   //Push the tasks corresponding to each date in dateList to the corresponding array element of taskElements
-  sortedTasks.forEach((task, index) => {
-    if(index > 0 && dateList.indexOf(task.date) >= 0 ) {taskElementArrays[dateList.indexOf(task.date)].push(
+  sortedTasks.forEach(task => {
+    if(dateList.indexOf(task.date) >= 0 ) {taskElementArrays[dateList.indexOf(task.date)].push(
       TaskComponent(task)
     )}
-    else if (index > 0) {taskElementArrays[taskElementArrays.length - 1].push(
+    else {taskElementArrays[taskElementArrays.length - 1].push(
       TaskComponent(task)
     )}
   })
@@ -148,7 +147,6 @@ export default function GroupedTask(props){
       return (runningTotal + calcElapsedTime(currentTask.props.task))
     }, 0)
   })
-
 
   function handleSelect() {
     console.log(selectAll)

--- a/Client/src/Components/Task/Task.jsx
+++ b/Client/src/Components/Task/Task.jsx
@@ -22,7 +22,7 @@ export default function Task(props){
   const newGroupListElements = groupData.map(group => {
     if (group.group_id != 0 && group.group_id != 1) {
       if (taskDropdownSearch == "" || group.title.toUpperCase().indexOf(taskDropdownSearch.toUpperCase()) === 0) {
-        return <p key = {group.group_id} id = {group.group_id} className = {'group-list#' + task.task_id} onClick={() => dropdownSelected(event)}>{group.title}</p>
+        return <p key = {group.group_id} id = {group.group_id} className = {'group-list#' + task.task_id} onClick={() => dropdownSelected(event, false)}>{group.title}</p>
       }
     } 
     else {return}
@@ -54,12 +54,12 @@ export default function Task(props){
               defaultValue = {task.title}
               type = "text" 
               name = "title"
-              onChange = {() => handleInputChange(event)} 
+              onChange = {() => handleInputChange(event, false)} 
             />
           </div>
           <span className="line-divider"></span>
           <div className="task-dropdown">
-            <div className="group task-drop-btn" onClick={() => dropdown(event)}>
+            <div className="group task-drop-btn" onClick={() => dropdown(event, false)}>
               <p key = {task.groupId} id = {'group#' + task.task_id} ref = {taskBtnRef}>{task.group_title}</p>
             </div>
             <div id="task-group-dropdown" className={newClassList} >
@@ -70,8 +70,8 @@ export default function Task(props){
                 className = "task-dropdown-input"
                 id = {'dropdown-input#' + task.task_id}
                 name = "group" 
-                onChange = {() => dropdownFilter(event)} 
-                onKeyDown = {() => dropdownEnter(event)}
+                onChange = {() => dropdownFilter(event, false)} 
+                onKeyDown = {() => dropdownEnter(event, false)}
               />
               {newGroupListElements}
             </div>
@@ -89,7 +89,7 @@ export default function Task(props){
               name = "startTime"
               defaultValue = {task.start_time}  
               type = "time" 
-              onChange = {() => handleInputChange(event)} 
+              onChange = {() => handleInputChange(event, false)} 
             />
             <div className="time-divider">-</div>
             <input 
@@ -97,7 +97,7 @@ export default function Task(props){
               name = "endTime"
               defaultValue = {task.end_time} 
               type = "time"
-              onChange = {() => handleInputChange(event)} 
+              onChange = {() => handleInputChange(event, false)} 
             />
           </div>
           <input 
@@ -106,7 +106,7 @@ export default function Task(props){
             type = "date" 
             defaultValue = {task.date} 
             name = "date"
-            onChange = {() => handleInputChange(event)} 
+            onChange = {() => handleInputChange(event, false)} 
           />
           <span className="line-divider"></span>
           <div className = "task-date">
@@ -116,7 +116,7 @@ export default function Task(props){
               type = "date" 
               defaultValue = {task.date} 
               name = "date"
-              onChange = {() => handleInputChange(event)} 
+              onChange = {() => handleInputChange(event, false)} 
             />
           </div>
           <span className="line-divider"></span>


### PR DESCRIPTION
Can we keep these functions on the homepage and apply them to both CreateTask and GroupedTasks, or did you want to put separate functions in each of those components?  I can see how separating them would make the code easier to understand, but it would also result in some repeated code, since these functions do some of the same things whether they are applied to CreateTask or GroupedTasks.  In this commit, I commented out the newly created dropdown functions in the CreateTask component for now and applied the original functions from the Homepage instead.  I also moved the state variable "selected" to the homepage and sent it to CreateTask as a prop.